### PR TITLE
Fixed ui bug at /dashboard

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -50,7 +50,7 @@ const App: React.FC = () => {
         <Route
           path="/dashboard"
           element={
-            isAuthenticated ? <DashboardPage /> : <Navigate to="/" replace />
+            isAuthenticated ? <DashboardPage /> : <div></div>
           }
         />
       </Routes>

--- a/client/src/components/AppSidebar.tsx
+++ b/client/src/components/AppSidebar.tsx
@@ -1,54 +1,53 @@
-import { 
+import {
   LayoutDashboard,
   Newspaper,
   Map,
   LayoutList,
-  MessageSquare
- } from "lucide-react"
+  MessageSquare,
+} from 'lucide-react';
 
 import {
   Sidebar,
   SidebarContent,
   SidebarHeader,
   SidebarFooter,
-} from "@/components/ui/sidebar"
+} from '@/components/ui/sidebar';
 
-import NavGroup from "@/components/sidebar/nav-main"
-import NavUser from "@/components/sidebar/nav-user"
+import NavGroup from '@/components/sidebar/nav-main';
+import NavUser from '@/components/sidebar/nav-user';
 
-import { useUser } from "@/contexts/UserContext";
-
+import { useUser } from '@/contexts/UserContext';
 
 // Menu items.
 const items = {
   navExplore: [
     {
-      title: "Dashboard",
-      url: "/",
+      title: 'Dashboard',
+      url: '/dashboard',
       icon: LayoutDashboard,
     },
     {
-      title: "Feed",
-      url: "/feed",
+      title: 'Feed',
+      url: '/feed',
       icon: Newspaper,
     },
     {
-      title: "Places",
-      url: "/places",
+      title: 'Places',
+      url: '/places',
       icon: Map,
-    }
+    },
   ],
   navManageBookings: [
     {
-      title: "Chats",
-      url: "/chats",
+      title: 'Chats',
+      url: '/chats',
       icon: MessageSquare,
     },
     {
-      title: "Pending Approvals",
-      url: "/approvals",
+      title: 'Pending Approvals',
+      url: '/approvals',
       icon: LayoutList,
-    }
+    },
   ],
 };
 
@@ -63,8 +62,11 @@ export function AppSidebar() {
 
       {/* Main navigation */}
       <SidebarContent>
-        <NavGroup groupLabel='Explore' items={items.navExplore} />
-        <NavGroup groupLabel='Manage Bookings' items={items.navManageBookings} />
+        <NavGroup groupLabel="Explore" items={items.navExplore} />
+        <NavGroup
+          groupLabel="Manage Bookings"
+          items={items.navManageBookings}
+        />
       </SidebarContent>
 
       {/* Footer: User Profile */}
@@ -74,7 +76,6 @@ export function AppSidebar() {
         ) : (
           <p className="p-4 text-sm">Not logged in</p>
         )}
-        
       </SidebarFooter>
     </Sidebar>
   );


### PR DESCRIPTION
# Description

Just a fix of the bug from May 25's meeting where clicking on the "dashboard" tab in the sidebar returns to the sign up/ log in page, even though the user is logged in.

<img width="904" alt="Screenshot 2025-05-27 at 10 45 14 PM" src="https://github.com/user-attachments/assets/889f191f-b805-4790-9cbd-d305ec333d1c" />

